### PR TITLE
Add twitar_macro and twitar_macro_derive for procedural macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1846,6 +1846,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "twitar_macro"
+version = "0.1.0"
+
+[[package]]
+name = "twitar_macro_derive"
+version = "0.1.0"
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 [workspace]
 members = [
-    "twitar"
+    "twitar",
+    "twitar_macro",
+    "twitar_macro_derive",
 ]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+```
+cargo run -p twitar
+```

--- a/twitar_macro/Cargo.toml
+++ b/twitar_macro/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "twitar_macro"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/twitar_macro/src/lib.rs
+++ b/twitar_macro/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}

--- a/twitar_macro_derive/Cargo.toml
+++ b/twitar_macro_derive/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "twitar_macro_derive"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/twitar_macro_derive/src/lib.rs
+++ b/twitar_macro_derive/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
- MIgrate to cargo workspaces
- Add `twitar_macro and `twitar_macro_derive` crate